### PR TITLE
better defaults, support for one PSF frame, IFS support for non-esorex command

### DIFF
--- a/Examples/VCAL_params_calib_IFS.json
+++ b/Examples/VCAL_params_calib_IFS.json
@@ -28,7 +28,7 @@
     "flat_smooth_length": 10,
     "specpos_distort_corr": 1,
     "specpos_nonlin_corr": 1,
-    "poly_order_wc": 0,
+    "poly_order_wc": 2,
     "wc_win_sz": 4,
     "sky": 1,
     "manual_sky": 1,

--- a/Manual/VCAL_MANUAL_for_CALIBRATION.txt
+++ b/Manual/VCAL_MANUAL_for_CALIBRATION.txt
@@ -100,7 +100,7 @@ STEPS:
     "specpos_nonlin_corr": True, # See sph_ifs_spectra_positions description
 
     ## wavelength calibration
-    "poly_order_wc": 0, # The order of the polynomial to use for the wavelength model -> 1, 2, 3, or 0 for automatic. Default 2 in sph_ifs_wave_calib. If the order is 1, a linear model with constant dispersion is assumed. Recommended: 2 for a quadratic fit to the three lasers in YJ mode, and 3 for a cubic fit to the four lasers in YJH mode. Also see Samland+2022 Section 3.5. There is no calibration laser at 1.54µm, so the wavelength solution in these long wavelengths is an extrapolation.
+    "poly_order_wc": 2, # The order of the polynomial to use for the wavelength model -> 1, 2, 3, or 0 for automatic. Default 2 in sph_ifs_wave_calib. If the order is 1, a linear model with constant dispersion is assumed. Recommended: 2 for a quadratic fit to the three lasers in YJ mode, and 3 for a cubic fit to the four lasers in YJH mode. Also see Samland+2022 Section 3.5. There is no calibration laser at 1.54µm, so the wavelength solution in these long wavelengths is an extrapolation.
     "wc_win_sz": 4, # default is 4 in sph_ifs_wave_calib (but worked well with 2 on 2019-2020 datasets). Half the tolerance around the predicted wavelength position to search for the actual maximum. This value should absolutely be smaller than the minimal distance between line wavelengths (in pixels).
 
     ## sky

--- a/README.rst
+++ b/README.rst
@@ -79,5 +79,4 @@ If you have questions on proper usage of the code, assess whether the data look 
 
 Acknowledgements
 ----------------
-The code will soon be placed on ASCL for a proper citation handle.
-In the meantime, if you use `vcal_sphere`, please cite `Christiaens et al. (2021) <https://ui.adsabs.harvard.edu/abs/2021MNRAS.502.6117C/abstract>`_. 
+If you use `vcal_sphere`, please cite `Christiaens et al. (2023) <https://ui.adsabs.harvard.edu/abs/2023ascl.soft11002C/abstract>`_.

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ for your environment):
 
 .. code-block:: bash
 
-  $ conda create -n vcal_env python=3.9 ipython
+  $ conda create -n vcal_env python=3.10 ipython
 
 Note: installing ipython while creating the environment with the above line will
 avoid a commonly reported issue which stems from trying to import VIP from 

--- a/vcal/calib/calib_SPHERE.py
+++ b/vcal/calib/calib_SPHERE.py
@@ -1034,14 +1034,14 @@ def calib(params_calib_name='VCAL_params_calib.json') -> None:
                 recipe = "dbi"
                 label_method = "DBI"
 
-            def _reduce_irdis_esorex(outpath_irdis_fits, outpath_irdis_sof, file, ii, recipe, file_type):
+            def _reduce_irdis_esorex(outpath_irdis_fits, outpath_irdis_sof, file, ii, recipe, com_esorex, file_type):
                 """
                 Short block to run the esorex command for IRDIS reduction.
                 """
                 if file.endswith(".fits"):
                     file = file[:-5]
 
-                command = f"esorex sph_ird_science_{recipe}"
+                command = f"{com_esorex} sph_ird_science_{recipe}"
                 command += f" --ird.science_{recipe}.outfilename={outpath_irdis_fits}{file}_total.fits"
                 command += f" --ird.science_{recipe}.outfilename_left={outpath_irdis_fits}{file}_left.fits"
                 command += f" --ird.science_{recipe}.outfilename_right={outpath_irdis_fits}{file}_right.fits"
@@ -1077,7 +1077,7 @@ def calib(params_calib_name='VCAL_params_calib.json') -> None:
 
                     if (not isfile(outpath_irdis_fits + f"{file}_left.fits") or
                             not isfile(outpath_irdis_fits + f"{file}_right.fits") or overwrite_sof or overwrite_fits):
-                        _reduce_irdis_esorex(outpath_irdis_fits, outpath_irdis_sof, file, ii, recipe,
+                        _reduce_irdis_esorex(outpath_irdis_fits, outpath_irdis_sof, file, ii, recipe, com_esorex,
                                              file_type="OBJECT")
 
             # CEN
@@ -1109,7 +1109,8 @@ def calib(params_calib_name='VCAL_params_calib.json') -> None:
 
                     if (not isfile(outpath_irdis_fits + f"{file}_left.fits") or
                             not isfile(outpath_irdis_fits + f"{file}_right.fits") or overwrite_sof or overwrite_fits):
-                        _reduce_irdis_esorex(outpath_irdis_fits, outpath_irdis_sof, file, ii, recipe, file_type="CEN")
+                        _reduce_irdis_esorex(outpath_irdis_fits, outpath_irdis_sof, file, ii, recipe, com_esorex,
+                                             file_type="CEN")
 
             # PSF
             psf_list_irdis = dico_lists['psf_list_irdis']
@@ -1139,7 +1140,8 @@ def calib(params_calib_name='VCAL_params_calib.json') -> None:
 
                     if (not isfile(outpath_irdis_fits + f"{file}_left.fits") or
                             not isfile(outpath_irdis_fits + f"{file}_right.fits") or overwrite_sof or overwrite_fits):
-                        _reduce_irdis_esorex(outpath_irdis_fits, outpath_irdis_sof, file, ii, recipe, file_type="PSF")
+                        _reduce_irdis_esorex(outpath_irdis_fits, outpath_irdis_sof, file, ii, recipe, com_esorex,
+                                             file_type="PSF")
 
             # remove the stacked left and right sides called "_total"
             os.system(f"rm {outpath_irdis_fits}*_total.fits")

--- a/vcal/calib/calib_SPHERE.py
+++ b/vcal/calib/calib_SPHERE.py
@@ -220,7 +220,7 @@ def calib(params_calib_name='VCAL_params_calib.json') -> None:
             poly_order_wc = 2
         elif mode == "YJH":
             poly_order_wc = 3
-    wc_win_sz = params_calib.get('wc_win_sz', 2)  # default: 4
+    wc_win_sz = params_calib.get('wc_win_sz', 4)  # default: 4
     # for IFS only, will subtract the sky before the science_dr recipe (corrects also for dark, incl. bias, and vast majority of bad pixels!!)
     sky = params_calib.get('sky', 1)
     verbose = params_calib.get('verbose', 1)

--- a/vcal/calib/calib_SPHERE.py
+++ b/vcal/calib/calib_SPHERE.py
@@ -1255,11 +1255,11 @@ def calib(params_calib_name='VCAL_params_calib.json') -> None:
             with open(outpath_ifs_sof + "master_dark.sof", 'w+') as f:
                 for ii in range(len(dark_list_ifs)):
                     dark_cube, dark_head = open_fits(inpath + dark_list_ifs[ii], header=True, verbose=False)
-                    if np.round(dark_head['HIERARCH ESO DET SEQ1 DIT'], decimals=2) == 1.65 and dark_head[
-                        "MJD-OBS"] < 0:
-                        # if it's 1.65s and before the shutdown, replace with the super dark
-                        dark_list_ifs[ii] = "ifs_super_dark_1.65s.fits"
-                        os.system("cp {} {}".format(vcal_path[0][:-4] + "Static/ifs_super_dark_1.65s.fits", inpath))
+                    # if np.round(dark_head['HIERARCH ESO DET SEQ1 DIT'], decimals=2) == 1.65 and dark_head[
+                    #     "MJD-OBS"] < 0:
+                    #     # if it's 1.65s and before the shutdown, replace with the super dark
+                    #     dark_list_ifs[ii] = "ifs_super_dark_1.65s.fits"
+                    #     os.system("cp {} {}".format(vcal_path[0][:-4] + "Static/ifs_super_dark_1.65s.fits", inpath))
                     f.write(inpath + dark_list_ifs[ii] + '\t' + 'IFS_DARK_RAW\n')
                     if dark_cube.ndim == 3:
                         if ii == 0:
@@ -1324,10 +1324,10 @@ def calib(params_calib_name='VCAL_params_calib.json') -> None:
                             dark_cube, fdark_head = open_fits(inpath + fdark_list_ifs[dd], header=True, verbose=False)
                             dit_fdark = fdark_head['HIERARCH ESO DET SEQ1 DIT']
                             if dit_fdark == fdit:
-                                if np.round(dit_fdark, decimals=2) == 1.65 and fdark_head["MJD-OBS"] < 0:
-                                    fdark_list_ifs[dd] = "ifs_super_dark_1.65s.fits"
-                                    os.system("cp {} {}".format(vcal_path[0][:-4] + "Static/ifs_super_dark_1.65s.fits",
-                                                                inpath))
+                                # if np.round(dit_fdark, decimals=2) == 1.65 and fdark_head["MJD-OBS"] < 0:
+                                #     fdark_list_ifs[dd] = "ifs_super_dark_1.65s.fits"
+                                #     os.system("cp {} {}".format(vcal_path[0][:-4] + "Static/ifs_super_dark_1.65s.fits",
+                                #                                 inpath))
                                 f.write(inpath + fdark_list_ifs[dd] + '\t' + 'IFS_DARK_RAW\n')
                                 master_dark_cube[counter:counter + dark_cube.shape[0]] = np.copy(dark_cube)
                                 counter += dark_cube.shape[0]

--- a/vcal/preproc/preproc_IFS.py
+++ b/vcal/preproc/preproc_IFS.py
@@ -1267,7 +1267,8 @@ def preproc_IFS(params_preproc_name='VCAL_params_preproc_IFS.json',
                     header = fits.Header()
                     header['Flux 0'] = 'Flux scaled to coronagraphic DIT'
                     header['Flux 1'] = 'Flux measured in PSF image'
-                    write_fits(outpath+final_fluxname+".fits", np.array([med_flux*dit_ifs/dit_psf_ifs, med_flux]),
+                    header['Flux 2'] = 'Flux measured in PSF image scale to 1s'
+                    write_fits(outpath+final_fluxname+".fits", np.array([med_flux*dit_ifs/dit_psf_ifs, med_flux, med_flux/dit_psf_ifs]),
                                header=header, verbose=debug)
                     write_fits(outpath+final_fwhmname+".fits", fwhm, verbose=debug)
 

--- a/vcal/preproc/preproc_IFS.py
+++ b/vcal/preproc/preproc_IFS.py
@@ -214,9 +214,11 @@ def preproc_IFS(params_preproc_name='VCAL_params_preproc_IFS.json',
 
     # List of OBJ and PSF files
     dico_lists = {}
-    dico_files = reader(open(path+'dico_files.csv', 'r'))
-    for row in dico_files:
-         dico_lists[row[0]] = literal_eval(row[1])
+    with open(path + "dico_files.csv", 'r') as csvfile:
+        csv_file = reader(csvfile)
+        for row in csv_file:
+            dico_lists[row[0]] = literal_eval(row[1])
+    csvfile.close()
 
     prefix = [sky_pre+"SPHER",sky_pre+"psf_SPHER",sky_pre+"cen_SPHER"]
     #if len(dico_lists['sci_list_ifs'])>0:

--- a/vcal/preproc/preproc_IFS.py
+++ b/vcal/preproc/preproc_IFS.py
@@ -543,8 +543,8 @@ def preproc_IFS(params_preproc_name='VCAL_params_preproc_IFS.json',
                             cube, header = open_fits(outpath+filename+"_1bpcorr.fits", header=True, verbose=debug)
                             if fi == 1 or not coro:
                                 cube_med = np.median(cube, axis=0)  # median combine all channels
-                                # low pass filter, search in subframe that avoids empty data in the edges
-                                y_max, x_max = peak_coordinates(cube_med, fwhm=int(1.2*max_resel),
+                                # search in subframe that avoids empty data in the edges
+                                y_max, x_max = peak_coordinates(cube_med, fwhm=1,
                                                                 approx_peak=frame_center(cube_med), search_box=85)
                                 xy = (x_max, y_max)
                                 if debug:

--- a/vcal/preproc/preproc_IRDIS.py
+++ b/vcal/preproc/preproc_IRDIS.py
@@ -755,7 +755,7 @@ def preproc_IRDIS(params_preproc_name='VCAL_params_preproc_IRDIS.json',
                             pacy = header["ESO INS1 PAC Y"]/18
                             n_fr = cube.shape[0]
                             if "2dfit" in rec_met_tmp:
-                                if n_fr == 1:  # can have one frame, e.g. broad band imaging and only one PSF file
+                                if cube.ndim == 2:  # can have one frame
                                     tmp = frame_filter_lowpass(cube)
                                 else:
                                     tmp = frame_filter_lowpass(np.median(cube,axis=0))

--- a/vcal/preproc/preproc_IRDIS.py
+++ b/vcal/preproc/preproc_IRDIS.py
@@ -753,9 +753,12 @@ def preproc_IRDIS(params_preproc_name='VCAL_params_preproc_IRDIS.json',
                             cube = np.nan_to_num(cube, copy=False)  # check for nans
                             pacx = header["ESO INS1 PAC X"]/18  # 18 microns -> pixels, ref SPHERE manual
                             pacy = header["ESO INS1 PAC Y"]/18
-                            n_fr=cube.shape[0]
+                            n_fr = cube.shape[0]
                             if "2dfit" in rec_met_tmp:
-                                tmp = frame_filter_lowpass(np.median(cube,axis=0))
+                                if n_fr == 1:  # can have one frame, e.g. broad band imaging and only one PSF file
+                                    tmp = frame_filter_lowpass(cube)
+                                else:
+                                    tmp = frame_filter_lowpass(np.median(cube,axis=0))
                                 y_max, x_max = np.unravel_index(np.argmax(tmp),tmp.shape)
                                 cube, y_shifts, x_shifts = cube_recenter_2dfit(cube, xy=(int(x_max), int(y_max)),
                                                                                fwhm=1.2*resel[ff], subi_size=cen_box_sz[fi], model=rec_met_tmp[:-6],


### PR DESCRIPTION
Pretty chill pull request this time around: 

- updated the `poly_order_wc` and `wc_win_sz` default _in all locations_  as I missed a few last time
- turned off low pass filtering of the PSF frames to find the location of the star for the IFS. After a lot of testing, I don't think the filtering helps 
- 2D Gaussian centering can work with a single PSF frame for IRDIS (can be quite common! especially with classical imaging where esorex combines the PSF cube into a single frame) 
- final_flux.fits includes flux per second as third number in array, and updated header
- dico_files.csv gets closed after initial read
- IFS part of the pipeline supports non-esorex commands (the com_esorex variable) 